### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -106,7 +106,7 @@ en-core-web-trf==3.4.1
     # via -r requirements.in
 entrypoints==0.4
     # via jupyter-client
-evaluate==0.2.2
+evaluate==0.3.0
     # via setfit
 exceptiongroup==1.0.0rc9
     # via hypothesis


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.